### PR TITLE
Drag item into grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "ng test",
     "serve:ssr:client": "node dist/client/server/server.mjs"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "^18.0.0",
     "@angular/common": "^18.0.0",

--- a/projects/client/src/app/app.component.html
+++ b/projects/client/src/app/app.component.html
@@ -1,4 +1,4 @@
-<button (click)="addItem()">Add Item</button>
+<button (click)="addItemTop()">Add Item</button>
 <label> Cols:
   <input type="number" [(ngModel)]="columns" placeholder="cols">
 </label>
@@ -15,21 +15,32 @@
   </label>
 </label>
 
-<ddl-grid [columns]="columns" #grid
+<ddl-grid [columns]="columns" #gridTop class="grid-top"
           [rows]="rows"
           [colGap]="colGap"
           [rowGap]="rowGap"
-          [(items)]="items">
-  <ddl-item *ngFor="let item of items; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
+          [(items)]="itemsTop">
+  <ddl-item *ngFor="let item of itemsTop; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
     <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>
 
-<div class="drag-items" ddlDragItems [grids]="[grid]">
+<div class="drag-items" ddlDragItems [grids]="[gridTop, gridBottom]">
   <div ddlDragItem
        class="drag-item"
        [draggable]="i === 0"
        [disabled]="i == 1"
        *ngFor="let dragItem of dragItems; let i = index">{{dragItem}}</div>
 </div>
+
+<ddl-grid [columns]="columns" #gridBottom class="grid-bottom"
+          [rows]="rows"
+          [colGap]="colGap"
+          [rowGap]="rowGap"
+          [(items)]="itemsBottom">
+  <ddl-item *ngFor="let item of itemsBottom; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
+    <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
+    <div ddlDragHandle class="drag-handle">Handle</div>
+  </ddl-item>
+</ddl-grid>

--- a/projects/client/src/app/app.component.html
+++ b/projects/client/src/app/app.component.html
@@ -15,7 +15,7 @@
   </label>
 </label>
 
-<ddl-grid [columns]="columns"
+<ddl-grid [columns]="columns" #grid
           [rows]="rows"
           [colGap]="colGap"
           [rowGap]="rowGap"
@@ -25,3 +25,11 @@
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>
+
+<div class="drag-items" ddlDragItems [grids]="[grid]">
+  <div ddlDragItem
+       class="drag-item"
+       [draggable]="i === 0"
+       [disabled]="i == 1"
+       *ngFor="let dragItem of dragItems; let i = index">{{dragItem}}</div>
+</div>

--- a/projects/client/src/app/app.component.html
+++ b/projects/client/src/app/app.component.html
@@ -22,6 +22,7 @@
           [(items)]="itemsTop">
   <ddl-item *ngFor="let item of itemsTop; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
     <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
+    <span class="item-info-data">{{item.data}}</span>
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>
@@ -29,8 +30,11 @@
 <div class="drag-items" ddlDragItems [grids]="[gridTop, gridBottom]">
   <div ddlDragItem
        class="drag-item"
-       [draggable]="i === 0"
+       [draggable]="true"
        [disabled]="i == 1"
+       [width]="2"
+       [height]="2"
+       [dragData]="i"
        *ngFor="let dragItem of dragItems; let i = index">{{dragItem}}</div>
 </div>
 
@@ -41,6 +45,7 @@
           [(items)]="itemsBottom">
   <ddl-item *ngFor="let item of itemsBottom; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
     <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
+    <span class="item-info-data">{{item.data}}</span>
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>

--- a/projects/client/src/app/app.component.less
+++ b/projects/client/src/app/app.component.less
@@ -22,5 +22,16 @@
   background-color: #f0f0f0;
   position: absolute;
   top: 15px;
-  right: 15px;
+  left: 15px;
+}
+
+.grid-top {
+  border: 2px solid #4aaaa7;
+  width: 70%;
+  margin-left: 30%;
+  margin-top: 40%;
+}
+
+.grid-bottom {
+  border: 2px solid #ca3921;
 }

--- a/projects/client/src/app/app.component.less
+++ b/projects/client/src/app/app.component.less
@@ -4,6 +4,13 @@
   top: 40%;
 }
 
+.item-info-data {
+  position: absolute;
+  left: 40%;
+  top: 60%;
+  color: #4aaaa7;
+}
+
 .drag-items {
   margin-top: 2em;
   width: 100%;

--- a/projects/client/src/app/app.component.less
+++ b/projects/client/src/app/app.component.less
@@ -4,6 +4,18 @@
   top: 40%;
 }
 
+.drag-items {
+  margin-top: 2em;
+  width: 100%;
+
+  .drag-item {
+    padding: 1em;
+    background-color: white;
+    width: fit-content;
+    margin-bottom: 0.3em;
+  }
+}
+
 .drag-handle {
   cursor: move;
   height: 20px;

--- a/projects/client/src/app/app.component.ts
+++ b/projects/client/src/app/app.component.ts
@@ -17,25 +17,30 @@ export class AppComponent {
   public colGap: number = 20;
   public rowGap: number = 20;
 
-  public items: Item[] = [
+  public itemsTop: Item[] = [
     new Item('0', 6, 2, 2, 2),
     new Item('1', 2, 2, 2, 1),
     new Item('2', 11, 3, 1, 2),
   ];
 
+  public itemsBottom: Item[] = [
+    new Item('3', 6, 2, 2, 2),
+    new Item('4', 2, 2, 2, 1),
+  ];
+
   public resizeTypes: ResizeType[] = ['bottom-right', 'right', 'top-left', 'left', 'bottom-left', 'top', 'bottom', 'top-right'];
   public dragItems: string[] = ['Item 1', 'Item 2', 'Item 3'];
 
-  public addItem(): void {
-    if (this.items.length === 0) {
-      this.items.push(new Item('0', 1, 1, 1, 1));
+  public addItemTop(): void {
+    if (this.itemsTop.length === 0) {
+      this.itemsTop.push(new Item('0', 1, 1, 1, 1));
     } else {
-      const lastItem = this.items[this.items.length - 1];
+      const lastItem = this.itemsTop[this.itemsTop.length - 1];
       const newItem = lastItem.clone();
       newItem.id = (parseInt(lastItem.id) + 1).toString();
       newItem.x = lastItem.x + 1;
       newItem.y = lastItem.y + 1;
-      this.items.push(newItem);
+      this.itemsTop.push(newItem);
     }
   }
 

--- a/projects/client/src/app/app.component.ts
+++ b/projects/client/src/app/app.component.ts
@@ -1,13 +1,18 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import {GridComponent, ItemComponent, Item, itemTrackBy, DragHandleDirective, DragItemDirective, DragItemsDirective, ResizeType} from 'drag-drop-layout';
+import {
+  Item,
+  itemTrackBy,
+  ResizeType,
+  DdlModule
+} from 'drag-drop-layout';
 import {NgForOf} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NgForOf, FormsModule, GridComponent, ItemComponent, DragHandleDirective, DragItemDirective, DragItemsDirective],
+  imports: [RouterOutlet, NgForOf, FormsModule, DdlModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.less'
 })

--- a/projects/client/src/app/app.component.ts
+++ b/projects/client/src/app/app.component.ts
@@ -18,14 +18,14 @@ export class AppComponent {
   public rowGap: number = 20;
 
   public itemsTop: Item[] = [
-    new Item('0', 6, 2, 2, 2),
-    new Item('1', 2, 2, 2, 1),
-    new Item('2', 11, 3, 1, 2),
+    new Item('0', 6, 2, 2, 2, 'Item 0 | TOP'),
+    new Item('1', 2, 2, 2, 1, 'Item 1 | TOP'),
+    new Item('2', 11, 3, 1, 2, 'Item 2 | TOP'),
   ];
 
   public itemsBottom: Item[] = [
-    new Item('3', 6, 2, 2, 2),
-    new Item('4', 2, 2, 2, 1),
+    new Item('3', 6, 2, 2, 2, 'Item 3 | BOTTOM'),
+    new Item('4', 2, 2, 2, 1, 'Item 4 | BOTTOM'),
   ];
 
   public resizeTypes: ResizeType[] = ['bottom-right', 'right', 'top-left', 'left', 'bottom-left', 'top', 'bottom', 'top-right'];

--- a/projects/client/src/app/app.component.ts
+++ b/projects/client/src/app/app.component.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import {GridComponent, ItemComponent, Item, itemTrackBy, DragHandleDirective, ResizeType} from 'drag-drop-layout';
+import {GridComponent, ItemComponent, Item, itemTrackBy, DragHandleDirective, DragItemDirective, DragItemsDirective, ResizeType} from 'drag-drop-layout';
 import {NgForOf} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NgForOf, FormsModule, GridComponent, ItemComponent, DragHandleDirective],
+  imports: [RouterOutlet, NgForOf, FormsModule, GridComponent, ItemComponent, DragHandleDirective, DragItemDirective, DragItemsDirective],
   templateUrl: './app.component.html',
   styleUrl: './app.component.less'
 })
@@ -24,6 +24,7 @@ export class AppComponent {
   ];
 
   public resizeTypes: ResizeType[] = ['bottom-right', 'right', 'top-left', 'left', 'bottom-left', 'top', 'bottom', 'top-right'];
+  public dragItems: string[] = ['Item 1', 'Item 2', 'Item 3'];
 
   public addItem(): void {
     if (this.items.length === 0) {

--- a/projects/drag-drop-layout/package.json
+++ b/projects/drag-drop-layout/package.json
@@ -1,6 +1,15 @@
 {
-  "name": "drag-drop-layout",
+  "name": "@skutam/drag-drop-layout",
+  "description": "Angular library that uses CSS grid for dragging and resizing elements.",
   "version": "0.0.1",
+  "keywords": [
+    "angular",
+    "drag",
+    "drop",
+    "layout",
+    "grid",
+    "resize"
+  ],
   "peerDependencies": {
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0"

--- a/projects/drag-drop-layout/src/lib/ddl.module.ts
+++ b/projects/drag-drop-layout/src/lib/ddl.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import {GridComponent} from "./grid/grid.component";
+import {ItemComponent} from "./item/item.component";
+import {DragHandleDirective} from "./directives/drag-handle.directive";
+import {DragItemDirective} from "./directives/drag-item.directive";
+import {DragItemsDirective} from "./directives/drag-items.directive";
+import {GridService} from "./services/grid.service";
+import {GridDragItemService} from "./services/grid-drag-item.service";
+
+
+
+@NgModule({
+  imports: [
+    GridComponent,
+    ItemComponent,
+    DragHandleDirective,
+    DragItemDirective,
+    DragItemsDirective,
+  ],
+  exports: [
+    GridComponent,
+    ItemComponent,
+    DragHandleDirective,
+    DragItemDirective,
+    DragItemsDirective,
+  ],
+  providers: [
+    GridService,
+    GridDragItemService,
+  ]
+})
+export class DdlModule { }

--- a/projects/drag-drop-layout/src/lib/directives/drag-handle.directive.ts
+++ b/projects/drag-drop-layout/src/lib/directives/drag-handle.directive.ts
@@ -8,7 +8,7 @@ export class DragHandleDirective {
   public dragStart = output<PointerEvent>();
 
   @HostListener('pointerdown', ['$event'])
-  private startDrag(event: PointerEvent) {
+  public startDrag(event: PointerEvent) {
     /**
      * Only start dragging if the left mouse button is pressed.
      * https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#determining_button_states

--- a/projects/drag-drop-layout/src/lib/directives/drag-item.directive.ts
+++ b/projects/drag-drop-layout/src/lib/directives/drag-item.directive.ts
@@ -44,11 +44,7 @@ export class DragItemDirective implements OnDestroy {
     event.preventDefault();
 
     this.dragStart.emit(event);
-    const {x, y} = this.dragItem.nativeElement.getBoundingClientRect();
-    this.gridService.startItemDrag(this.getItem(), event, {
-      x: x - event.clientX,
-      y: y - event.clientY,
-    });
+    this.gridService.startItemDrag(this.getItem(), this.dragItem.nativeElement, event);
 
     this.gridService.pointerMove$.pipe(
       takeUntilDestroyed(this.destroyRef),
@@ -73,6 +69,6 @@ export class DragItemDirective implements OnDestroy {
   }
 
   public getItem(): Item {
-    return new Item(this.id, 0, 0, this.width(), this.height());
+    return new Item('dragItem', 0, 0, this.width(), this.height(), this.dragData());
   }
 }

--- a/projects/drag-drop-layout/src/lib/directives/drag-item.directive.ts
+++ b/projects/drag-drop-layout/src/lib/directives/drag-item.directive.ts
@@ -1,0 +1,87 @@
+import {Directive, ElementRef, HostListener, Inject, input, OnDestroy, output} from '@angular/core';
+import {GridDragItemService} from "../services/grid-drag-item.service";
+import {Item} from "../item/item.definitions";
+
+@Directive({
+  selector: '[ddlDragItem]',
+  standalone: true,
+  host: {
+    '[draggable]': 'draggable()',
+    '[disabled]': 'disabled()',
+    '[style.cursor]': 'disabled() ? "not-allowed" : (draggable() ? "move" : "default")',
+  },
+})
+export class DragItemDirective implements OnDestroy {
+  private static dragItemIdCounter: number = 0;
+  public id: string = `${DragItemDirective.dragItemIdCounter++}`;
+
+  // Inputs
+  public draggable = input(true);
+  public disabled = input(false);
+  public dragData = input<any>();
+
+  public width = input(1);
+  public height = input(1);
+
+  // Outputs
+  public dragStart = output<PointerEvent>();
+  public dragMove = output<PointerEvent>();
+  public dragEnd = output<PointerEvent>();
+
+  private _dragging: boolean = false;
+
+  @HostListener('pointerdown', ['$event'])
+  private startDrag(event: PointerEvent) {
+    /**
+     * Only start dragging if the left mouse button is pressed.
+     * https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#determining_button_states
+     */
+    if (!this.draggable() || event.button !== 0 && event.buttons !== 1) {
+      return;
+    }
+
+    this._dragging = true;
+    this.dragStart.emit(event);
+    event.preventDefault();
+  }
+
+  // TODO: Add debounce to this, so that it doesn't fire too often
+  @HostListener('document:pointermove', ['$event'])
+  protected moveDrag(event: PointerEvent) {
+    if (!this._dragging) {
+      return;
+    }
+
+    this.dragMove.emit(event);
+    event.preventDefault();
+  }
+
+  @HostListener('document:pointerup', ['$event'])
+  protected dragResizeEnd(event: PointerEvent) {
+    if (!this._dragging) {
+      return;
+    }
+
+    this.dragEnd.emit(event);
+    this._dragging = false;
+    event.preventDefault();
+  }
+
+  public constructor(
+    @Inject(ElementRef) private item: ElementRef<HTMLElement>,
+    private gridDragItemService: GridDragItemService,
+  ) { }
+
+  public ngOnDestroy(): void {
+    this.gridDragItemService.unregisterItem(this);
+  }
+
+  public getItem(): Item {
+    return new Item(
+      this.id,
+      0,
+      0,
+      this.width(),
+      this.height());
+  }
+}

--- a/projects/drag-drop-layout/src/lib/directives/drag-items.directive.ts
+++ b/projects/drag-drop-layout/src/lib/directives/drag-items.directive.ts
@@ -1,44 +1,38 @@
 import {
   AfterViewInit,
-  ContentChildren,
+  ContentChildren, DestroyRef,
   Directive,
   input,
   InputSignal,
-  OnDestroy,
   QueryList
 } from '@angular/core';
 import {DragItemDirective} from "./drag-item.directive";
-import {Subscription} from "rxjs";
 import {GridComponent} from "../grid/grid.component";
 import {GridDragItemService} from "../services/grid-drag-item.service";
+import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 
 @Directive({
   selector: '[ddlDragItems]',
   standalone: true
 })
-export class DragItemsDirective implements AfterViewInit, OnDestroy {
+export class DragItemsDirective implements AfterViewInit {
   @ContentChildren(DragItemDirective, {descendants: true}) private itemDirectives!: QueryList<DragItemDirective>;
-  private itemSubscription: Subscription | null = null;
 
   // Inputs
   public grids: InputSignal<GridComponent[]> = input<GridComponent[]>([]);
 
   constructor(
     private gridDragItemService: GridDragItemService,
-  ) {
-  }
+    private destroyRef: DestroyRef,
+  ) { }
 
   public ngAfterViewInit(): void {
-    this.itemSubscription = this.itemDirectives.changes.subscribe(() => {
+    this.itemDirectives.changes.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => {
       this.registerItems();
     });
     this.registerItems();
-  }
-
-  public ngOnDestroy(): void {
-    if (this.itemSubscription) {
-      this.itemSubscription.unsubscribe();
-    }
   }
 
   private registerItems(): void {

--- a/projects/drag-drop-layout/src/lib/directives/drag-items.directive.ts
+++ b/projects/drag-drop-layout/src/lib/directives/drag-items.directive.ts
@@ -1,0 +1,49 @@
+import {
+  AfterViewInit,
+  ContentChildren,
+  Directive,
+  input,
+  InputSignal,
+  OnDestroy,
+  QueryList
+} from '@angular/core';
+import {DragItemDirective} from "./drag-item.directive";
+import {Subscription} from "rxjs";
+import {GridComponent} from "../grid/grid.component";
+import {GridDragItemService} from "../services/grid-drag-item.service";
+
+@Directive({
+  selector: '[ddlDragItems]',
+  standalone: true
+})
+export class DragItemsDirective implements AfterViewInit, OnDestroy {
+  @ContentChildren(DragItemDirective, {descendants: true}) private itemDirectives!: QueryList<DragItemDirective>;
+  private itemSubscription: Subscription | null = null;
+
+  // Inputs
+  public grids: InputSignal<GridComponent[]> = input<GridComponent[]>([]);
+
+  constructor(
+    private gridDragItemService: GridDragItemService,
+  ) {
+  }
+
+  public ngAfterViewInit(): void {
+    this.itemSubscription = this.itemDirectives.changes.subscribe(() => {
+      this.registerItems();
+    });
+    this.registerItems();
+  }
+
+  public ngOnDestroy(): void {
+    if (this.itemSubscription) {
+      this.itemSubscription.unsubscribe();
+    }
+  }
+
+  private registerItems(): void {
+    this.grids().forEach((grid) => {
+      this.gridDragItemService.registerItems(grid, this.itemDirectives.toArray());
+    });
+  }
+}

--- a/projects/drag-drop-layout/src/lib/grid/grid.component.ts
+++ b/projects/drag-drop-layout/src/lib/grid/grid.component.ts
@@ -34,11 +34,11 @@ export class GridComponent implements AfterViewInit, OnDestroy {
   @ContentChildren(ItemComponent, {descendants: true}) private itemComponents!: QueryList<ItemComponent>;
 
   // Inputs
-  public columns = input(12);
-  public rows = input(3);
-  public colGap= input(8);
-  public rowGap = input(8);
-  public items = model([] as Item[]);
+  public columns = input<number>(12);
+  public rows = input<number>(3);
+  public colGap= input<number>(8);
+  public rowGap = input<number>(8);
+  public items = model<Item[]>([] as Item[]);
 
   // Outputs
   public dragEnter = output<GridEvent>();

--- a/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
+++ b/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
@@ -6,6 +6,7 @@ export interface GridEvent {
   grid: GridComponent;
   event: PointerEvent;
   item: Item;
+  draggingItemRect: DOMRect;
 }
 
 export interface GridRectData {
@@ -21,6 +22,7 @@ export interface IDragResizeData {
   fromGrid: GridComponent | null;
   item: Item;
   itemComponent: ItemComponent | null;
+  dragItemElement: HTMLElement | null;
   dragging: boolean; // Differentiate between dragging and resizing
   previousGrid: GridComponent | null; // The grid the item was previously in the last pinter move check
   currentGrid: GridComponent | null;  // The grid the item is currently in, used to trigger dragEnter and dragLeave events

--- a/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
+++ b/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
@@ -1,8 +1,40 @@
 import {GridComponent} from "./grid.component";
 import {Item} from "../item/item.definitions";
+import {ItemComponent} from "../item/item.component";
 
 export interface GridEvent {
   grid: GridComponent;
   event: PointerEvent;
   item: Item;
+}
+
+export interface GridRectData {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  cellWidth: number;
+  cellHeight: number;
+}
+
+export interface IDragResizeData {
+  fromGrid: GridComponent | null;
+  item: Item;
+  itemComponent: ItemComponent | null;
+  dragging: boolean; // Differentiate between dragging and resizing
+  previousGrid: GridComponent | null; // The grid the item was previously in the last pinter move check
+  currentGrid: GridComponent | null;  // The grid the item is currently in, used to trigger dragEnter and dragLeave events
+  dragOffset: { // The offset of the item from the top left corner of the grid to the pointer on drag start
+    x: number;
+    y: number;
+  };
+  itemOffset: {
+    x: number;
+    y: number;
+  }
+}
+
+export interface IGridPointerEvent {
+  event: PointerEvent;
+  dragResizeData: IDragResizeData;
 }

--- a/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
+++ b/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
@@ -1,0 +1,8 @@
+import {GridComponent} from "./grid.component";
+import {Item} from "../item/item.definitions";
+
+export interface GridEvent {
+  grid: GridComponent;
+  event: PointerEvent;
+  item: Item;
+}

--- a/projects/drag-drop-layout/src/lib/item/item.component.ts
+++ b/projects/drag-drop-layout/src/lib/item/item.component.ts
@@ -18,8 +18,9 @@ import {
 } from '@angular/core';
 import {Item, ItemDragEvent, ItemResizeEvent, ResizeType} from "./item.definitions";
 import {DragHandleDirective} from "../directives/drag-handle.directive";
-import {Subscription} from "rxjs";
+import {Subscription, take, takeUntil} from "rxjs";
 import {NgForOf} from "@angular/common";
+import {GridService} from "../services/grid.service";
 
 
 @Component({
@@ -141,6 +142,7 @@ export class ItemComponent implements AfterViewInit, OnDestroy {
 
   public constructor(
     @Inject(ElementRef) private item: ElementRef<HTMLDivElement>,
+    private gridService: GridService,
   ) {
     this.registerPropertyEffect('--ddl-item-x', this.x);
     this.registerPropertyEffect('--ddl-item-y', this.y);
@@ -182,6 +184,15 @@ export class ItemComponent implements AfterViewInit, OnDestroy {
       item: this.getItem(),
       event: event,
     });
+    this.gridService.pointerMove.pipe(
+      takeUntil(this.gridService.pointerEnd),
+    ).subscribe((event: PointerEvent) => {
+      this.dragMove.emit({
+        item: this.getItem(),
+        event: event,
+      });
+    })
+    this.gridService.startDrag(this.getItem(), this);
     event.preventDefault();
   }
 

--- a/projects/drag-drop-layout/src/lib/item/item.component.ts
+++ b/projects/drag-drop-layout/src/lib/item/item.component.ts
@@ -49,6 +49,7 @@ export class ItemComponent implements AfterViewInit, OnDestroy {
   public y = signal(0);
   public width = signal(1);
   public height = signal(1);
+  public data = signal<any>(undefined);
 
   // Inputs
   public resizeTypes: InputSignal<ResizeType[]> = input(['bottom-left'] as ResizeType[]);
@@ -185,6 +186,6 @@ export class ItemComponent implements AfterViewInit, OnDestroy {
   }
 
   public getItem(): Item {
-    return new Item(this.id, this.x(), this.y(), this.width(), this.height());
+    return new Item(this.id, this.x(), this.y(), this.width(), this.height(), this.data());
   }
 }

--- a/projects/drag-drop-layout/src/lib/item/item.definitions.ts
+++ b/projects/drag-drop-layout/src/lib/item/item.definitions.ts
@@ -38,6 +38,7 @@ export class Item {
   public height: number = 1;
   public x: number = 0;
   public y: number = 0;
+  public data: any = undefined;
 
   public constructor(
     id: string,
@@ -45,15 +46,16 @@ export class Item {
     y: number,
     width: number,
     height: number,
-  ) {
+    data: any = undefined) {
     this.id = id;
     this.width = width;
     this.height = height;
     this.x = x;
     this.y = y;
+    this.data = data;
   }
 
   public clone(): Item {
-    return new Item(this.id, this.x, this.y, this.width, this.height);
+    return new Item(this.id, this.x, this.y, this.width, this.height, this.data);
   }
 }

--- a/projects/drag-drop-layout/src/lib/placeholder.ts
+++ b/projects/drag-drop-layout/src/lib/placeholder.ts
@@ -1,14 +1,13 @@
+import {Item} from "./item/item.definitions";
+
 export class Placeholder {
   private readonly placeholder: HTMLElement;
-  public width: number = 0;
-  public height: number = 0;
-  public x: number = 0;
-  public y: number = 0;
+  private readonly item: Item;
 
   constructor(
-    document: Document,
+    private _document: Document,
   ) {
-    this.placeholder = document.createElement('div');
+    this.placeholder = this._document.createElement('div');
     this.placeholder.style.backgroundColor = '#256';
     this.placeholder.style.position = 'absolute';
     this.placeholder.style.border = '1px dashed #000';
@@ -17,33 +16,50 @@ export class Placeholder {
     this.placeholder.style.pointerEvents = 'none';
     this.placeholder.style.zIndex = '1000';
     this.placeholder.style.opacity = '0.0';
-    document.body.appendChild(this.placeholder);
+    this._document.body.appendChild(this.placeholder);
+
+    this.item = new Item('', 0, 0, 0, 0);
   }
 
-  public createPlaceholder(width: number, height: number, x: number, y: number): void {
+  protected createPlaceholder(width: number, height: number, x: number, y: number): void {
     this.placeholder.style.width = `${width}px`;
     this.placeholder.style.height = `${height}px`;
     this.placeholder.style.left = `${x}px`;
     this.placeholder.style.top = `${y}px`;
     this.placeholder.style.opacity = '0.60';
 
-    this.width = width;
-    this.height = height;
-    this.x = x;
-    this.y = y;
+    this.item.width = width;
+    this.item.height = height;
+    this.item.x = x;
+    this.item.y = y;
+    console.log('Placeholder created', this.item);
   }
 
   public movePlaceholder(x: number, y: number): void {
+    console.log('Moving placeholder', x, y);
     this.placeholder.style.left = `${x}px`;
     this.placeholder.style.top = `${y}px`;
   }
 
   public resizePlaceholder(width: number, height: number): void {
+    console.log('Resizing placeholder', width, height);
     this.placeholder.style.width = `${width}px`;
     this.placeholder.style.height = `${height}px`;
   }
 
-  public destroyPlaceholder(): void {
+  /**
+   * Destroy the placeholder
+   * Handled by the grid service
+   */
+  protected destroyPlaceholder(): void {
     this.placeholder.style.opacity = '0.0';
+    this.item.x = 0;
+    this.item.y = 0;
+    this.item.width = 0;
+    this.item.height = 0;
+  }
+
+  public getItem(): Item {
+    return this.item;
   }
 }

--- a/projects/drag-drop-layout/src/lib/placeholder.ts
+++ b/projects/drag-drop-layout/src/lib/placeholder.ts
@@ -32,17 +32,14 @@ export class Placeholder {
     this.item.height = height;
     this.item.x = x;
     this.item.y = y;
-    console.log('Placeholder created', this.item);
   }
 
   public movePlaceholder(x: number, y: number): void {
-    console.log('Moving placeholder', x, y);
     this.placeholder.style.left = `${x}px`;
     this.placeholder.style.top = `${y}px`;
   }
 
   public resizePlaceholder(width: number, height: number): void {
-    console.log('Resizing placeholder', width, height);
     this.placeholder.style.width = `${width}px`;
     this.placeholder.style.height = `${height}px`;
   }

--- a/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import {GridComponent} from "../grid/grid.component";
+import {DragItemDirective} from "../directives/drag-item.directive";
+import {BehaviorSubject, Observable} from "rxjs";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GridDragItemService {
+  private grids = new Map<GridComponent, BehaviorSubject<DragItemDirective[]>>();
+
+  constructor() { }
+
+  public getGridItems(grid: GridComponent): Observable<DragItemDirective[]> {
+    if (!this.grids.has(grid)) {
+      throw new Error('Grid not registered');
+    }
+    return this.grids.get(grid)!;
+  }
+
+  /**
+   * Register a grid with the service, needs to be called when the grid is constructed
+   */
+  public registerGrid(grid: GridComponent): void {
+    if (this.grids.has(grid)) {
+      throw new Error('Grid already registered');
+    }
+    this.grids.set(grid, new BehaviorSubject<DragItemDirective[]>([]));
+  }
+
+  public unregisterGrid(grid: GridComponent): void {
+    if (!this.grids.has(grid)) {
+      throw new Error('Grid not registered');
+    }
+    this.grids.delete(grid);
+  }
+
+  public registerItems(grid: GridComponent, items: DragItemDirective[]): void {
+    if (!this.grids.has(grid)) {
+      throw new Error('Grid not registered');
+    }
+
+    // Add the items to the grid items, ignore duplicates
+    const gridItems = this.grids.get(grid)!.getValue();
+    this.grids.get(grid)!.next([...gridItems, ...items.filter((item) => !gridItems.includes(item))]);
+  }
+
+  public unregisterItem(item: DragItemDirective): void {
+    this.grids.forEach((items) => {
+      items.next(items.getValue().filter((i) => i !== item));
+    });
+  }
+}

--- a/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
@@ -18,6 +18,10 @@ export class GridDragItemService {
     return this.grids.get(grid)!;
   }
 
+  public getGrids(): GridComponent[] {
+    return Array.from(this.grids.keys());
+  }
+
   /**
    * Register a grid with the service, needs to be called when the grid is constructed
    */

--- a/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid-drag-item.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import {GridComponent} from "../grid/grid.component";
 import {DragItemDirective} from "../directives/drag-item.directive";
-import {BehaviorSubject, Observable} from "rxjs";
+import {BehaviorSubject} from "rxjs";
 
 @Injectable({
   providedIn: 'root'
@@ -10,13 +10,6 @@ export class GridDragItemService {
   private grids = new Map<GridComponent, BehaviorSubject<DragItemDirective[]>>();
 
   constructor() { }
-
-  public getGridItems(grid: GridComponent): Observable<DragItemDirective[]> {
-    if (!this.grids.has(grid)) {
-      throw new Error('Grid not registered');
-    }
-    return this.grids.get(grid)!;
-  }
 
   public getGrids(): GridComponent[] {
     return Array.from(this.grids.keys());

--- a/projects/drag-drop-layout/src/lib/services/grid.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid.service.ts
@@ -1,0 +1,72 @@
+import {HostListener, Injectable} from '@angular/core';
+import {Item} from "../item/item.definitions";
+import {ItemComponent} from "../item/item.component";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GridService {
+  private currentlyDraggingItem: Item | null = null;
+  private currentlyDraggingItemComponent: ItemComponent | null = null;
+
+  private _dragging = false;
+  private _resizing = false;
+
+  @HostListener('document:pointermove', ['$event'])
+  private dragResizeMove(event: PointerEvent) {
+    if (!this._dragging && !this._resizing) {
+      return;
+    }
+
+    if (this._dragging) {
+      this.dragMove(event);
+    } else {
+      this.resizeMove(event);
+    }
+    event.preventDefault();
+  }
+
+  @HostListener('document:pointerup', ['$event'])
+  private dragResizeStop(event: PointerEvent) {
+    if (!this._dragging && !this._resizing) {
+      return;
+    }
+
+    if (this._dragging) {
+      this.dragEnd(event);
+    } else {
+      this.resizeEnd(event);
+    }
+    this._dragging = false;
+    this._resizing = false;
+    event.preventDefault();
+  }
+
+  constructor() { }
+
+  public startDrag(item: Item, itemCom: ItemComponent): void {
+    this._dragging = true;
+    this.currentlyDraggingItem = item;
+    this.currentlyDraggingItemComponent = itemCom;
+  }
+
+  public dragMove(event: PointerEvent): void {
+
+  }
+
+  public dragEnd(event: PointerEvent): void {
+  }
+
+
+  public startResize(item: Item, resizeType: string): void {
+    this._resizing = true;
+    this.currentlyDraggingItem = item;
+  }
+
+  public resizeMove(event: PointerEvent): void {
+
+  }
+
+  public resizeEnd(event: PointerEvent): void {
+  }
+}

--- a/projects/drag-drop-layout/src/lib/services/grid.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid.service.ts
@@ -1,64 +1,169 @@
 import {DestroyRef, Inject, Injectable, NgZone} from '@angular/core';
 import {Item} from "../item/item.definitions";
 import {ItemComponent} from "../item/item.component";
-import {DOCUMENT} from "@angular/common";
 import {
   filter,
   fromEvent,
   Observable,
   sampleTime,
   Subject,
-  takeUntil
 } from "rxjs";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
+import {GridComponent} from "../grid/grid.component";
+import {GridDragItemService} from "./grid-drag-item.service";
+import {Placeholder} from "../placeholder";
+import {IDragResizeData, IGridPointerEvent} from "../grid/grid.definitions";
+import {DOCUMENT} from "@angular/common";
+
 
 @Injectable({
   providedIn: 'root'
 })
-export class GridService {
-  private _dragging = false;
-  private _resizing = false;
+export class GridService extends Placeholder {
+  private dragResizeData: IDragResizeData | null = null;
 
-  public pointerMove: Observable<PointerEvent>;
-  private pointerMoveSubject: Subject<PointerEvent> = new Subject<PointerEvent>();
+  public pointerMove$: Observable<IGridPointerEvent>;
+  private pointerMoveSubject: Subject<IGridPointerEvent> = new Subject<IGridPointerEvent>();
 
-  public pointerEnd: Observable<PointerEvent>;
-  private pointerEndSubject: Subject<PointerEvent> = new Subject<PointerEvent>();
+  public pointerEnd$: Observable<IGridPointerEvent>;
+  private pointerEndSubject: Subject<IGridPointerEvent> = new Subject<IGridPointerEvent>();
 
   constructor(
-    @Inject(DOCUMENT) private document: Document,
     private destroyRef: DestroyRef,
     private ngZone: NgZone,
+    private gridDragItemService: GridDragItemService,
+    @Inject(DOCUMENT) private document: Document,
   ) {
-    this.pointerMove = this.pointerMoveSubject.asObservable();
-    this.pointerEnd = this.pointerEndSubject.asObservable();
+    super(document);
+    this.pointerMove$ = this.pointerMoveSubject.asObservable();
+    this.pointerEnd$ = this.pointerEndSubject.asObservable();
 
     this.ngZone.runOutsideAngular(() => {
       fromEvent<PointerEvent>(this.document, 'pointermove').pipe(
-        takeUntil(this.pointerEnd),
-        sampleTime(20),
-        filter(() => this._dragging || this._resizing),
+        sampleTime(10),
         takeUntilDestroyed(this.destroyRef),
+        filter(() => this.dragResizeData !== null),
       ).subscribe((event: PointerEvent) => {
-        this.pointerMoveSubject.next(event);
+        // Calculate movement only when dragging, resize handles it on its own
+        if (this.dragResizeData!.dragging) {
+          this.handleGridPointerMove(event);
+
+          const newDeltaX = event.clientX + this.dragResizeData!.dragOffset.x + window.scrollX;
+          const newDeltaY = event.clientY + this.dragResizeData!.dragOffset.y + window.scrollY;
+          this.movePlaceholder(newDeltaX, newDeltaY);
+        }
+
+        this.pointerMoveSubject.next({
+          event,
+          dragResizeData: this.dragResizeData!,
+        });
       });
 
       fromEvent<PointerEvent>(this.document, 'pointerup').pipe(
-        filter(() => this._dragging || this._resizing),
         takeUntilDestroyed(this.destroyRef),
+        filter(() => this.dragResizeData !== null),
       ).subscribe((event: PointerEvent) => {
-        this._dragging = false;
-        this._resizing = false;
-        this.pointerEndSubject.next(event);
+        this.dragResizeData = null;
+        this.destroyPlaceholder();
+        this.pointerEndSubject.next({
+          event,
+          dragResizeData: this.dragResizeData!,
+        });
       });
     });
   }
 
-  public startDrag(item: Item, itemCom: ItemComponent): void {
-    this._dragging = true;
+  public startDrag(fromGrid: GridComponent | null, item: Item,
+                   itemComponent: ItemComponent, event: PointerEvent,
+                   itemOffset: {x: number, y: number}): void {
+    console.log('Start drag', item);
+    const {width, height, x, y} = itemComponent.element.getBoundingClientRect();
+    this.createPlaceholder(width, height, x + window.scrollX, y + window.scrollY);
+
+    this.dragResizeData = {
+      fromGrid,
+      item,
+      itemComponent,
+      dragging: true,
+      currentGrid: null,
+      previousGrid: null,
+      dragOffset: {
+        x: x - event.clientX,
+        y: y - event.clientY,
+      },
+      itemOffset
+    };
   }
 
-  public startResize(item: Item, resizeType: string): void {
-    this._resizing = true;
+  public startItemDrag(item: Item, event: PointerEvent, dragOffset: {x: number, y: number}) {
+    this.dragResizeData = {
+      fromGrid: null,
+      item,
+      itemComponent: null,
+      dragging: true,
+      currentGrid: null,
+      previousGrid: null,
+      dragOffset,
+      itemOffset: {
+        x: 0,
+        y: 0,
+      },
+    };
+  }
+
+  public startResize(item: Item, itemComponent: ItemComponent, event: PointerEvent): void {
+    const {width, height, x, y} = itemComponent.element.getBoundingClientRect();
+    this.createPlaceholder(width, height, x + window.scrollX, y + window.scrollY);
+
+    this.dragResizeData = {
+      fromGrid: null,
+      item,
+      itemComponent,
+      dragging: false,
+      currentGrid: null,
+      previousGrid: null,
+      dragOffset: {
+        x: x - event.clientX,
+        y: y - event.clientY,
+      },
+      itemOffset: {
+        x: 0,
+        y: 0,
+      },
+    }
+  }
+
+  /**
+   * Handle the pointer move event, by checking if the item entered a new grid or left the current grid.
+   * If the item entered a new grid, the dragEnter event is emitted on the new grid.
+   * If the item left the current grid, the dragLeave event is emitted on the current grid.
+   */
+  private handleGridPointerMove(event: PointerEvent): void {
+    if (this.dragResizeData === null) {
+      return;
+    }
+
+    // Check if the item being dragged is still inside the same grid
+    if (this.dragResizeData.currentGrid !== null) {
+      if (this.dragResizeData.currentGrid.eventInsideGrid(event)) {
+        return;
+      }
+    }
+
+    // Not inside the same grid, notify previous grid
+    this.dragResizeData.previousGrid = this.dragResizeData.currentGrid;
+    this.dragResizeData.previousGrid?.dragLeave.emit({
+      grid: this.dragResizeData.previousGrid,
+      event,
+      item: this.dragResizeData.item,
+    });
+
+    // Find the new grid and notify it
+    this.dragResizeData.currentGrid = this.gridDragItemService.getGrids().find((grid) => grid.eventInsideGrid(event)) || null;
+    this.dragResizeData.currentGrid?.dragEnter.emit({
+      grid: this.dragResizeData.currentGrid,
+      event,
+      item: this.dragResizeData.item,
+    });
   }
 }

--- a/projects/drag-drop-layout/src/lib/util.ts
+++ b/projects/drag-drop-layout/src/lib/util.ts
@@ -1,0 +1,3 @@
+export function clamp(min: number, max: number, value: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/projects/drag-drop-layout/src/public-api.ts
+++ b/projects/drag-drop-layout/src/public-api.ts
@@ -5,3 +5,5 @@ export * from './lib/grid/grid.component';
 export * from './lib/item/item.component';
 export * from './lib/item/item.definitions';
 export * from './lib/directives/drag-handle.directive';
+export * from './lib/directives/drag-item.directive';
+export * from './lib/directives/drag-items.directive';

--- a/projects/drag-drop-layout/src/public-api.ts
+++ b/projects/drag-drop-layout/src/public-api.ts
@@ -7,3 +7,4 @@ export * from './lib/item/item.definitions';
 export * from './lib/directives/drag-handle.directive';
 export * from './lib/directives/drag-item.directive';
 export * from './lib/directives/drag-items.directive';
+export * from './lib/ddl.module';


### PR DESCRIPTION
### Pull Request Description

**Title:** Fix Drag Item Calculation and Add Cross-Grid Drag-and-Drop Feature

**Description:**

This pull request includes the following changes:

1. **Fixed Calculation of Dragging Items:**
   - Corrected the logic for calculating the position of dragging items into their corresponding columns and rows.
   - Ensured accurate placement of items within the grid during drag-and-drop operations.

2. **Added Cross-Grid Drag-and-Drop Feature:**
   - Implemented functionality to allow dragging items from one grid and dropping them into another.
   - Enhanced the drag-and-drop experience by enabling seamless movement of items between different grids.

**Changes:**
- Modified the `GridDragItemService` to handle the registration and management of multiple grids.
- Updated the `startDrag` method to include checks for resizable handles and to support cross-grid dragging.
- Adjusted the drag-and-drop logic to ensure items are correctly placed in their new grid positions.

**Testing:**
- Verified that items can be dragged and dropped within the same grid accurately.
- Tested the new feature by dragging items from one grid to another and ensuring they are placed correctly.
- Ensured that resizable handles are ignored during drag operations.

**Impact:**
- Improves the user experience by providing more flexibility in managing grid items.
- Fixes existing issues with item placement during drag-and-drop operations.

**Notes:**
- Ensure to test the drag-and-drop functionality thoroughly across different browsers and devices.