### PR TITLE
Fix click trigger item drag

### DIFF
--- a/projects/client/src/app/app.component.html
+++ b/projects/client/src/app/app.component.html
@@ -15,6 +15,10 @@
   </label>
 </label>
 
+<label>
+  <input type="checkbox" [(ngModel)]="showRemoveItemButton"> Show remove button
+</label>
+
 <ddl-grid [columns]="columns" #gridTop class="grid-top"
           [rows]="rows"
           [colGap]="colGap"
@@ -24,6 +28,7 @@
   <ddl-item *ngFor="let item of itemsTop; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
     <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
     <span class="item-info-data">{{item.data}}</span>
+    <button *ngIf="showRemoveItemButton" class="remove-item-btn" (click)="removeItemTop(item.id)">x</button>
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>
@@ -47,6 +52,7 @@
   <ddl-item *ngFor="let item of itemsBottom; trackBy: itemTrackBy" [resizeTypes]="resizeTypes">
     <div class="item-info">{{item.id}} [{{item.x}},{{item.y}}] ({{item.width}},{{item.height}})</div>
     <span class="item-info-data">{{item.data}}</span>
+    <button *ngIf="showRemoveItemButton" class="remove-item-btn" (click)="removeItemBottom(item.id)">x</button>
     <div ddlDragHandle class="drag-handle">Handle</div>
   </ddl-item>
 </ddl-grid>

--- a/projects/client/src/app/app.component.less
+++ b/projects/client/src/app/app.component.less
@@ -42,3 +42,10 @@
 .grid-bottom {
   border: 2px solid #ca3921;
 }
+
+.remove-item-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  cursor: pointer;
+}

--- a/projects/client/src/app/app.component.ts
+++ b/projects/client/src/app/app.component.ts
@@ -6,14 +6,14 @@ import {
   DragDropLayoutModule,
   Item
 } from '@skutam/drag-drop-layout';
-import {NgForOf} from "@angular/common";
+import {NgForOf, NgIf} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {GridItemDroppedEvent} from "../../../drag-drop-layout/src/lib/grid/grid.definitions";
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, NgForOf, FormsModule, DragDropLayoutModule],
+  imports: [RouterOutlet, NgForOf, FormsModule, DragDropLayoutModule, NgIf],
   templateUrl: './app.component.html',
   styleUrl: './app.component.less'
 })
@@ -22,6 +22,8 @@ export class AppComponent {
   public rows: number = 4;
   public colGap: number = 20;
   public rowGap: number = 20;
+
+  public showRemoveItemButton: boolean = true;
 
   public itemsTop: Item[] = [
     new Item('0', 6, 2, 2, 2, 'Item 0 | TOP'),
@@ -34,7 +36,7 @@ export class AppComponent {
     new Item('4', 2, 2, 2, 1, 'Item 4 | BOTTOM'),
   ];
 
-  public resizeTypes: ResizeType[] = ['bottom-right', 'right', 'top-left', 'left', 'bottom-left', 'top', 'bottom', 'top-right'];
+  public resizeTypes: ResizeType[] = ['bottom-right', 'right', 'top-left', 'left', 'bottom-left', 'top', 'bottom'];
   public dragItems: string[] = ['Item 1', 'Item 2', 'Item 3'];
 
   public addItemTop(): void {
@@ -48,6 +50,14 @@ export class AppComponent {
       newItem.y = lastItem.y + 1;
       this.itemsTop.push(newItem);
     }
+  }
+
+  public removeItemTop(id: string): void {
+    this.itemsTop = this.itemsTop.filter((item) => item.id !== id);
+  }
+
+  public removeItemBottom(id: string): void {
+    this.itemsBottom = this.itemsBottom.filter((item) => item.id !== id);
   }
 
   public itemDropped(event: GridItemDroppedEvent): void {

--- a/projects/drag-drop-layout/src/lib/item/item.component.html
+++ b/projects/drag-drop-layout/src/lib/item/item.component.html
@@ -1,16 +1,6 @@
-<ng-content></ng-content>
-
+<!-- Resize handles must be a-top the ng-content so when some button is added it is not overlapped by the resize handle.  -->
 <div *ngFor="let resizeType of resizeTypes()"
      class="resize-handle"
      [class]="resizeType"
      (pointerdown)="startResize($event, resizeType)"></div>
-<!--
-<div class="resize-handle top-left" (pointerdown)="startResize($event, true, true)"></div>
-<div class="resize-handle top" (pointerdown)="startResize($event, false, true)"></div>
-<div class="resize-handle top-right" (pointerdown)="startResize($event, true, true)"></div>
-<div class="resize-handle right" (pointerdown)="startResize($event, true, false)"></div>
-<div class="resize-handle bottom-right" (pointerdown)="startResize($event, true, true)"></div>
-<div class="resize-handle bottom" (pointerdown)="startResize($event, false, true)"></div>
-<div class="resize-handle bottom-left" (pointerdown)="startResize($event, true, true)"></div>
-<div class="resize-handle left" (pointerdown)="startResize($event, true, false)"></div>
--->
+<ng-content></ng-content>

--- a/projects/drag-drop-layout/src/lib/item/item.component.ts
+++ b/projects/drag-drop-layout/src/lib/item/item.component.ts
@@ -67,9 +67,17 @@ export class ItemComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    if (this.dragHandles.length === 0) {
-      this.startDrag(event);
+    // When there are no drag handles, the whole item can be dragged.
+    if (this.dragHandles.length !== 0) {
+      return;
     }
+
+    // Check if the event target is the element itself, not a child element.
+    if (event.target !== this.item.nativeElement) {
+      return;
+    }
+
+    this.startDrag(event);
   }
 
   private dragHandleDragStartSubscriptions: OutputRefSubscription[] = [];


### PR DESCRIPTION
Fixes problem #6, where if we had an button inside item with no drag-handles specified, and we clicked this button the item started dragging itself.