### PR TITLE
Fixed visual bug on first drag into grid

### DIFF
--- a/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
+++ b/projects/drag-drop-layout/src/lib/grid/grid.definitions.ts
@@ -4,7 +4,7 @@ import {Item} from "../item/item.definitions";
 export interface GridEvent {
   event: PointerEvent;
   item: Item;
-  dragItemElement: HTMLElement | null;
+  dragResizeData: IDragResizeData;
 }
 
 export interface GridItemDroppedEvent {
@@ -22,12 +22,12 @@ export interface GridRectData {
 }
 
 export interface IDragResizeData {
-  fromGrid: GridComponent | null;
-  item: Item;
+  fromGrid: GridComponent | null;     // The grid the drag started from
+  previousGrid: GridComponent | null; // The grid the item was previously in the last pointer move check
+  currentGrid: GridComponent | null;  // The grid the item is currently in, used to trigger dragEnter and dragLeave events
+  item: Item;                           // The item being dragged, used primarily for holding information about the item when dragging between grids
   dragItemElement: HTMLElement | null; // The element of new item we are trying to drag into grid
   dragging: boolean; // Differentiate between dragging and resizing
-  previousGrid: GridComponent | null; // The grid the item was previously in the last pinter move check
-  currentGrid: GridComponent | null;  // The grid the item is currently in, used to trigger dragEnter and dragLeave events
   dragOffset: { // The offset of the item from the top left corner of the grid to the pointer on drag start
     x: number;
     y: number;

--- a/projects/drag-drop-layout/src/lib/services/grid.service.ts
+++ b/projects/drag-drop-layout/src/lib/services/grid.service.ts
@@ -156,7 +156,7 @@ export class GridService extends Placeholder {
     this.dragResizeData!.previousGrid?.dragLeave.emit({
       event,
       item: this.dragResizeData!.item,
-      dragItemElement: this.dragResizeData!.dragItemElement
+      dragResizeData: this.dragResizeData!,
     });
 
     // Find the new grid and notify it
@@ -164,7 +164,7 @@ export class GridService extends Placeholder {
     this.dragResizeData!.currentGrid?.dragEnter.emit({
       event,
       item: this.dragResizeData!.item,
-      dragItemElement: this.dragResizeData!.dragItemElement
+      dragResizeData: this.dragResizeData!,
     });
   }
 }


### PR DESCRIPTION
There was a visual bug where the Item would show itself in different position at first and then it would show correctly. Closes #17 